### PR TITLE
feat(lambda): attach optional permissions boundary to role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,7 @@ resource "aws_iam_role_policy" "fpjs_proxy_lambda" {
 
 resource "aws_iam_role" "fpjs_proxy_lambda" {
   name               = "fingerprint-pro-lambda-role-${local.integration_id}"
+  permissions_boundary = var.fpjs_proxy_lambda_role_permissions_boundary_arn
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,16 @@ variable "fpjs_shared_secret" {
     error_message = "value should only consist of alphanumeric values and dashes"
   }
 }
+
+variable "fpjs_proxy_lambda_role_permissions_boundary_arn" {
+  type        = string
+  description = "permissions boundary ARN for the role assumed by the Proxy lambda"
+  default     = null
+  validation {
+    condition = anytrue([
+      var.fpjs_proxy_lambda_role_permissions_boundary_arn == null,
+      can(regex("^arn:aws:iam::[[:digit:]]+:policy/.+"), var.fpjs_proxy_lambda_role_permissions_boundary_arn),
+    ])
+    error_message = "value must be a valid policy ARN or null"
+  }
+}


### PR DESCRIPTION
This change allows the consumer to attach a permissions boundary ARN to the role assumed by the Proxy Lambda. This will allow consumers whose orgs mandate role boundaries, to provide a pre-defined policy ARN to the role created by this module.
