### PR TITLE
Add support for locally built Lambda function

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/main.tf
+++ b/main.tf
@@ -100,12 +100,13 @@ data "aws_s3_object" "fpjs_integration_s3_bucket" {
 
 resource "aws_lambda_function" "fpjs_proxy_lambda" {
   description      = "Fingerprint Proxy Lambda@Edge function"
-  s3_bucket        = data.aws_s3_object.fpjs_integration_s3_bucket.bucket
-  s3_key           = data.aws_s3_object.fpjs_integration_s3_bucket.key
+  s3_bucket        = var.local_lambda_path == null ? data.aws_s3_object.fpjs_integration_s3_bucket.bucket : null
+  s3_key           = var.local_lambda_path == null ? data.aws_s3_object.fpjs_integration_s3_bucket.key : null
+  filename         = var.local_lambda_path != null ? var.local_lambda_path : null
   function_name    = "fingerprint-pro-cloudfront-lambda-${local.integration_id}"
   role             = aws_iam_role.fpjs_proxy_lambda.arn
   handler          = "fingerprintjs-pro-cloudfront-lambda-function.handler"
-  source_code_hash = data.aws_s3_object.fpjs_integration_s3_bucket.etag
+  source_code_hash = var.local_lambda_path == null ? data.aws_s3_object.fpjs_integration_s3_bucket.etag : var.local_lambda_hash
   memory_size      = 128
   timeout          = 10
 

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "aws_lambda_function" "fpjs_proxy_lambda" {
   function_name    = "fingerprint-pro-cloudfront-lambda-${local.integration_id}"
   role             = aws_iam_role.fpjs_proxy_lambda.arn
   handler          = "fingerprintjs-pro-cloudfront-lambda-function.handler"
-  source_code_hash = var.local_lambda_path == null ? data.aws_s3_object.fpjs_integration_s3_bucket.etag : var.local_lambda_hash
+  source_code_hash = var.local_lambda_path == null ? data.aws_s3_object.fpjs_integration_s3_bucket.etag : filemd5(var.local_lambda_path)
   memory_size      = 128
   timeout          = 10
 

--- a/main.tf
+++ b/main.tf
@@ -100,13 +100,13 @@ data "aws_s3_object" "fpjs_integration_s3_bucket" {
 
 resource "aws_lambda_function" "fpjs_proxy_lambda" {
   description      = "Fingerprint Proxy Lambda@Edge function"
-  s3_bucket        = var.local_lambda_path == null ? data.aws_s3_object.fpjs_integration_s3_bucket.bucket : null
-  s3_key           = var.local_lambda_path == null ? data.aws_s3_object.fpjs_integration_s3_bucket.key : null
-  filename         = var.local_lambda_path != null ? var.local_lambda_path : null
+  s3_bucket        = var.fetch_lambda_from_s3 ? data.aws_s3_object.fpjs_integration_s3_bucket.bucket : null
+  s3_key           = var.fetch_lambda_from_s3 ? data.aws_s3_object.fpjs_integration_s3_bucket.key : null
+  filename         = !var.fetch_lambda_from_s3 ? var.local_lambda_path : null
   function_name    = "fingerprint-pro-cloudfront-lambda-${local.integration_id}"
   role             = aws_iam_role.fpjs_proxy_lambda.arn
   handler          = "fingerprintjs-pro-cloudfront-lambda-function.handler"
-  source_code_hash = var.local_lambda_path == null ? data.aws_s3_object.fpjs_integration_s3_bucket.etag : filemd5(var.local_lambda_path)
+  source_code_hash = var.fetch_lambda_from_s3 ? data.aws_s3_object.fpjs_integration_s3_bucket.etag : filemd5(var.local_lambda_path)
   memory_size      = 128
   timeout          = 10
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,9 @@ variable "local_lambda_path" {
   default     = null
   description = "Path to locally built lambda function that should be used for deployment, instead of the lambda stored in S3 bucket. Should be in zip format."
 }
+
+variable "fetch_lambda_from_s3" {
+  type = bool
+  default = true
+  description = "Whether to fetch lambda code from Fingerprint S3 bucket. Should be set to `false` if `local_lambda_path` is used."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -40,10 +40,3 @@ variable "local_lambda_path" {
   default     = null
   description = "Path to locally built lambda function that should be used for deployment, instead of the lambda stored in S3 bucket. Should be in zip format."
 }
-
-variable "local_lambda_hash" {
-  type        = string
-  default     = null
-  description = "Hash of the locally built lambda function, can be used to determine whether new version of the function should be deployed. Only relevant if local_lambda_path is set."
-}
-

--- a/variables.tf
+++ b/variables.tf
@@ -34,3 +34,16 @@ variable "fpjs_proxy_lambda_role_permissions_boundary_arn" {
   description = "Permissions boundary ARN for the role assumed by the Proxy lambda. Make sure your permissions boundary allows the function to access the Secrets Manager secret created for the integration (`secretsmanager:GetSecretValue`) and create logs (`logs:CreateLogStream`, `logs:CreateLogGroup`, `logs:PutLogEvents`)."
   default     = null
 }
+
+variable "local_lambda_path" {
+  type        = string
+  default     = null
+  description = "Path to locally built lambda function that should be used for deployment, instead of the lambda stored in S3 bucket. Should be in zip format."
+}
+
+variable "local_lambda_hash" {
+  type        = string
+  default     = null
+  description = "Hash of the locally built lambda function, can be used to determine whether new version of the function should be deployed. Only relevant if local_lambda_path is set."
+}
+


### PR DESCRIPTION
This PR introduces the ability to use locally built AWS Lambda functions via `local_lambda_path` variable.