### PR TITLE
fix: remove usage of deprecated managed_policy_arns attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,11 +86,15 @@ resource "aws_iam_role_policy" "fpjs_proxy_lambda" {
   })
 }
 
+resource "aws_iam_role_policy_attachment" "fpjs_proxy_lambda" {
+  role       = aws_iam_role.fpjs_proxy_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
 resource "aws_iam_role" "fpjs_proxy_lambda" {
   name                 = "fingerprint-pro-lambda-role-${local.integration_id}"
   permissions_boundary = var.fpjs_proxy_lambda_role_permissions_boundary_arn
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
-  managed_policy_arns  = ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
 }
 
 data "aws_s3_object" "fpjs_integration_s3_bucket" {


### PR DESCRIPTION
The `managed_policy_arns` attribute on `aws_iam_role` resources has been deprecated. At the AWS API layer, the `managed_policy_arns` list is translated by Terraform to individual "attached role policy" resources.

Per the Terraform docs, using the `managed_policy_arns` attribute is equivalent to using a separate
`aws_iam_role_policy_attachments_exclusive` resource.

As a result, this commit switches from the `managed_policy_arns` attribute to a `aws_iam_role_policy_attachments_exclusive` resource.

After this change, upgrading the fingerprint_cloudfront_integration module and running a terraform apply will result in Terraform creating a new resource in its state, but there will be no corresponding state change in the AWS APIs. Terraform also no longer produces the warning about the argument being deprecated.

With a Terraform configuration that deployed the CloudFront integration, listing the attached role policies to the IAM role showed no change after running a `terraform apply` with the updated module. Output was something like:

```
aws iam list-attached-role-policies --role-name fingerprint-pro-lambda-role-a6a14d03e4de
{
    "AttachedPolicies": [
        {
            "PolicyName": "AWSLambdaBasicExecutionRole",
            "PolicyArn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
        }
    ]
}
```