### PR TITLE
Set terraform version to 5.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.57"
+      version = "< 6.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
I found using the current version of this module that the version used is 5.57 although it should be >= 5.57 and < 6.0.0
However, that was not the behaviour

```
- Finding hashicorp/aws versions matching ">= 3.0.0, >= 3.29.0, >= 4.0.0, >= 4.9.0, >= 4.18.0, >= 4.29.0, >= 4.33.0, >= 4.40.0, >= 4.47.0, >= 4.52.0, >= 4.54.0, >= 4.67.0, >= 5.0.0, >= 5.21.0, >= 5.27.0, >= 5.40.0, ~> 5.57.0, < 6.0.0"...
```

```
- Installing hashicorp/aws v5.57.0...
- Installed hashicorp/aws v5.57.0 (signed by HashiCorp)
```

After modifying the version of the provider to be <= 6.0.0, it works as expected